### PR TITLE
Add Sitemap to Resolve Search Indexing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gem 'jekyll'
 gem 'uswds-jekyll', :git => 'https://github.com/18F/uswds-jekyll.git'
+gem 'jekyll-sitemap'

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'jekyll'
+gem 'uswds-jekyll', :git => 'https://github.com/18F/uswds-jekyll.git'

--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,11 @@ editbranch: staging
 
 search_site_handle: idmprod
 
+# Lines below recommended by Search.gov team to allow indexing.
+url: "https://pacs.idmanagement.gov"
+plugins:
+  - jekyll-sitemap
+
 # Links
 # List links that you would like to appear on the top navigation bar here
 navbar:


### PR DESCRIPTION
@lachellel - This Pull Request will allow us to verify the changes recommended by the Search.gov team fix our indexing issue.

The Gem file added in this update is copied from PIV-Guides. I modified it to include the recommended jekyll-sitemap Gem. 

Once I confirm the site is indexing correctly, I'll submit similar requests for our other Playbooks.

Thanks,
Ryan
